### PR TITLE
Adding permission in the search SQL request

### DIFF
--- a/libs/feature/resource/server/src/lib/permissions/permissions.service.ts
+++ b/libs/feature/resource/server/src/lib/permissions/permissions.service.ts
@@ -54,7 +54,7 @@ export class ResourcePermissionService {
     const shareds = members.map((m) => m.resourceId)
 
     return {
-      read: circle.personal ? this.applyRestrictifReadRule(user, circle, members, descendants, shareds) : true,
+      read: circle.personal ? this.applyRestrictifReadRule(user, circle, members, descendants, shareds) : true, // This logic is implemented in ResourceService in method change please report any change
       write:
         (user.role === UserRoles.admin && !circle.personal) || // user is admin and circle is not personal
         shareds.includes(circle.id) || // user is member of the circle

--- a/libs/feature/resource/server/src/lib/resource.controller.ts
+++ b/libs/feature/resource/server/src/lib/resource.controller.ts
@@ -34,7 +34,7 @@ export class ResourceController {
       )
       total = response[1]
     } else {
-      const response = await this.resourceService.search(filters)
+      const response = await this.resourceService.search(filters, req.user.id)
       resources = Mapper.mapAll(response[0], ResourceDTO)
       total = response[1]
     }

--- a/libs/feature/resource/server/src/lib/resource.controller.ts
+++ b/libs/feature/resource/server/src/lib/resource.controller.ts
@@ -34,9 +34,16 @@ export class ResourceController {
       )
       total = response[1]
     } else {
-      const response = await this.resourceService.search(filters, req.user.id)
+      const response = await this.resourceService.search(filters, req.user.id) // returns only resources the user has read access to
       resources = Mapper.mapAll(response[0], ResourceDTO)
       total = response[1]
+      return new ListResponse({
+        total,
+        resources: resources.map((e) => {
+          Object.assign(e, { permissions: { read: true, write: false, manage: false } })
+          return e
+        }),
+      })
     }
 
     const resourceWithPermissions = await this.permissionService.userPermissionsOnResources(resources, req.user)


### PR DESCRIPTION
Vérifie que l'utilisateur à les permissions pour voir la ressource dans la requête SQL.

Avant les permissions était vérifiée après, le problème de cette approche est que l'on limite la requête SQL aux 15 premières lignes il est donc possible que l'on ait pas la permission de voir ces 15 ressources. On aura donc aucune ressource affichée. Nous n'avons pas le problème si on vérifie les permissions dans la requête SQL.